### PR TITLE
bugfix: lookup which catalog entry corresponds to 'life_expectancy'

### DIFF
--- a/data/api/owid/main.py
+++ b/data/api/owid/main.py
@@ -94,7 +94,7 @@ def extract_expectancy():
 
     all_data = []
     df = catalog.find("life_expectancy")
-    table = df.iloc[0].load()
+    table = df.loc[df['table'] == 'life_expectancy'].load()
     countries = table.groupby("country")
     column = "life_expectancy_0"
 


### PR DESCRIPTION
the original code relied on hardcoded indexing which meant that it actually returned life-expectancy at 60 instead of overall life expectancy